### PR TITLE
Update alc.py (importlib works a bit different)

### DIFF
--- a/scripts/alc.py
+++ b/scripts/alc.py
@@ -33,7 +33,7 @@ def load_module(m):
     try:
         mod = imp.load_source('mod', m)
     except IOError:
-        mod = importlib.import_module('mod', m)
+        mod = importlib.import_module(m)
 
     return mod
 


### PR DESCRIPTION
If you want to 'import x' with `importlib.import_module` the initial syntax does not work. Here is the change to amend this (7-character change, indeed).
