### PR TITLE
Feature timemgmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 *.py[cod]
 
 # C extensions

--- a/scripts/alc.py
+++ b/scripts/alc.py
@@ -83,6 +83,8 @@ def make_trainer(pars, mod, data):
         with gzip.open(cps[-1], 'rb') as fp:
             trainer = cPickle.load(fp)
             trainer.data = data
+
+            trainer.interruptions.append(time.time()-trainer.last_interruption)
     else:
         trainer = mod.new_trainer(pars, data)
 
@@ -112,6 +114,8 @@ def run(args, mod):
     last_pars = trainer.switch_to_best_pars()
     report = mod.make_report(pars, trainer, data)
     trainer.switch_to_pars(last_pars)
+
+    trainer.last_interruption = time.time()
 
     print '>>> saving to checkpoint'
     idx = contrib.to_checkpoint('.', trainer)


### PR DESCRIPTION
This helps fixing a "bug" of TimeElapsed: If an experiment is run with alchemie/trainer and interrupted and restarted long after, this is ignored by TimeElapsed as it simply compares current time and start time stamp of the overall experiment.